### PR TITLE
JB-149: Fix basic auth when OAuth 2.0 was added

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -102,7 +102,7 @@ class Config
             case self::AUTH_METHOD_OAUTH2:
                 return $value;
             default:
-                return false;
+                return CURLAUTH_BASIC;
         }
     }
 


### PR DESCRIPTION
The issue was setting the user/pass in CURL was moved into an `elseif` condition

https://github.com/MalibuCommerceDev/mconnect-magento2/pull/61/files#diff-762f1c3ffcec11dfa8e5875b16df8d983cc311217dd1493118a427a22bacd57bL107-L111

`getAuthenticationMethod` for basic auth was returning `false`, so the user/pass was never being set.

This should fix that.