### PR TITLE
AP-80: Fix bug where marking order as synced doesnt update order grid or prevent resync

### DIFF
--- a/Controller/Adminhtml/Order/MassSynced.php
+++ b/Controller/Adminhtml/Order/MassSynced.php
@@ -105,6 +105,7 @@ class MassSynced extends \Magento\Backend\App\Action
                 $queue = $queues->getFirstItem();
                 if ($queue) {
                     $queue->setStatus(QueueModel::STATUS_SUCCESS)
+                        ->setFinishedAt(date('Y-m-d H:i:s'))
                         ->save();
                     $countMassQueue++;
                 }

--- a/Model/Cron/Queue.php
+++ b/Model/Cron/Queue.php
@@ -409,6 +409,20 @@ class Queue
 
                 continue;
             }
+
+            $success = $this->queueCollectionFactory->create()
+                ->addFieldToFilter('status', ['eq' => QueueModel::STATUS_SUCCESS])
+                ->addFieldToFilter('code', ['eq' => OrderModel::CODE])
+                ->addFieldToFilter('action', ['eq' => QueueModel::ACTION_EXPORT])
+                ->addFieldToFilter('entity_id', ['eq' => $item->getEntityId()])
+                ->addFieldToFilter('created_at', ['from' => $item->getCreatedAt()])
+                ->getSize();
+            if ($success) {
+                // order was successfully processed elsewhere, prevent this queue from retrying again
+                $item->setRetryCount($maxRetryAmount)->save();
+                continue;
+            }
+
             $order = $this->salesOrderFactory->create()->load($item->getEntityId());
             if ($order->getStatus() == 'kount_review') {
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "malibucommerce/mconnect-magento2",
     "description": "Connect NAV with Magento 2",
     "type": "magento2-module",
-    "version": "2.21.4",
+    "version": "2.21.5",
     "require": {
         "magento/framework": ">=103.0.2",
         "php": "~7.4.0||>=8.0 <8.3",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MalibuCommerce_MConnect" setup_version="2.21.4">
+    <module name="MalibuCommerce_MConnect" setup_version="2.21.5">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
- [x] Fixes a bug where marking an order a synced doesn't update the order grid in the admin.  The issue is the `finished_at` column isn't being filled in, so this query isn't picking up the successful job

https://github.com/MalibuCommerceDev/mconnect-magento2/blob/a12215064391fc9289ae5d1450a44263a8c440d9/Model/ResourceModel/Customer/Grid/Collection.php#L15

- [x] It also adds a check in the retry process to prevent resyncs from running after they've been synced successfully