### PR TITLE
Support all PHP 8 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "2.23.3",
     "require": {
         "magento/framework": ">=103.0.2",
-        "php": "~7.4.0||>=8.0 <8.3",
+        "php": "~7.4.0||>=8.0",
         "ext-simplexml": "*",
         "ext-mbstring": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "malibucommerce/mconnect-magento2",
     "description": "Connect NAV with Magento 2",
     "type": "magento2-module",
-    "version": "2.23.3",
+    "version": "2.23.4",
     "require": {
         "magento/framework": ">=103.0.2",
         "php": "~7.4.0||>=8.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MalibuCommerce_MConnect" setup_version="2.23.3">
+    <module name="MalibuCommerce_MConnect" setup_version="2.23.4">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
Hi Maks,

We need to add support for PHP 8.3.  I've tested the module in local 8.3 environment and don't see any issues.

Really there's no reason to block future versions of PHP.  We can assume it will be compatible and deal with issues as they come up.

Thanks,
Steve